### PR TITLE
Refactor/1008

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   plugins: ["prettier"],
   rules: {
-    "prettier/prettier": "warn",
+    "prettier/prettier": "error",
     "no-var": "error",
     "no-unused-vars": "warn",
     "no-empty": "warn",

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -16,12 +16,13 @@ exports.getLogin = async (req, res, next) => {
   }
 
   try {
-    const userId = await userService.createUser(userInfo);
+    const { id, name } = await userService.createUser(userInfo);
 
     res.json({
       result: "success",
       data: {
-        userId,
+        userId: id,
+        name,
       },
     });
   } catch (err) {
@@ -58,12 +59,13 @@ exports.postSignup = async (req, res, next) => {
   userInfo.name = name;
 
   try {
-    const userId = await userService.createUser(userInfo);
+    const { id } = await userService.createUser(userInfo);
 
     res.json({
       result: "success",
       data: {
-        userId,
+        userId: id,
+        name,
       },
     });
   } catch (err) {

--- a/controllers/memoRoom.js
+++ b/controllers/memoRoom.js
@@ -73,10 +73,13 @@ exports.addNewMemoRoom = async (req, res, next) => {
   }
 
   try {
-    await memoRoomService.addNewMemoRoom(userId, name);
+    const newMemoRoomId = await memoRoomService.addNewMemoRoom(userId, name);
 
     res.json({
       result: "success",
+      data: {
+        newMemoRoomId,
+      }
     });
   } catch (err) {
     if (err.name === "MongoServerError") {

--- a/controllers/memoRoom.js
+++ b/controllers/memoRoom.js
@@ -164,10 +164,11 @@ exports.removeMemoRoom = async (req, res, next) => {
   }
 
   try {
-    await memoRoomService.removeMemoRoom(memoroomId);
+    const newMemoRooms = await memoRoomService.removeMemoRoom(userId, memoroomId);
 
     res.json({
       result: "success",
+      data: newMemoRooms,
     });
   } catch (err) {
     if (err.name === "MongoServerError") {

--- a/services/auth.js
+++ b/services/auth.js
@@ -6,8 +6,14 @@ exports.createUser = async (userInfo) => {
   if (!user) {
     const newUser = await User.create(userInfo);
 
-    return newUser._id;
+    return {
+      id: newUser._id,
+      name: newUser.name,
+    };
   }
 
-  return user._id;
+  return {
+    id: user._id,
+    name: user.name,
+  };
 };

--- a/services/memoRoom.js
+++ b/services/memoRoom.js
@@ -31,16 +31,18 @@ exports.getAllMemoRoom = async (userId) => {
 
   return {
     tags: Array.from(new Set(allTags)),
-    memoRoom: memoroomInfo,
+    memoRooms: memoroomInfo,
   };
 };
 
 exports.addNewMemoRoom = async (userId, roomName) => {
+  console.log(userId, roomName);
+
   const newMemoRoom = await MemoRoom.create({
     owner: userId,
     participants: [userId],
     name: roomName,
-  }).exec();
+  });
 
   await User.findByIdAndUpdate(userId, {
     $push: { rooms: newMemoRoom._id },

--- a/services/memoRoom.js
+++ b/services/memoRoom.js
@@ -48,9 +48,34 @@ exports.updateMemoRoomTitle = async (memoRoomId, roomName) => {
   await MemoRoom.findByIdAndUpdate(memoRoomId, { name: roomName }).exec();
 };
 
-exports.removeMemoRoom = async (memoRoomId) => {
+exports.removeMemoRoom = async (userId, memoRoomId) => {
   await Memo.deleteMany({ room: memoRoomId }).exec();
   await Chat.deleteMany({ room: memoRoomId }).exec();
   await User.updateMany({}, { $pull: { rooms: memoRoomId } }).exec();
   await MemoRoom.findByIdAndRemove(memoRoomId).exec();
+
+  const targetUser = await User.findById(userId).populate({
+    path: "rooms",
+    populate: { path: "memos" },
+  });
+
+  //flatMap으로 리팩토링 해보기 ..
+  const allTags = [];
+  const memoroomInfo = {};
+
+  targetUser.rooms.forEach((room) => {
+    const memoTags = room.memos.map((memo) => memo.tags);
+
+    allTags.push(...memoTags);
+
+    memoroomInfo[room._id] = {
+      name: room.name,
+      tags: Array.from(new Set(memoTags.flat(Infinity))),
+    };
+  });
+
+  return {
+    tags: Array.from(new Set(allTags.flat(Infinity))),
+    memoRooms: memoroomInfo,
+  };
 };

--- a/services/memoRoom.js
+++ b/services/memoRoom.js
@@ -15,10 +15,8 @@ exports.getAllMemoRoom = async (userId) => {
 
   targetUser.rooms.forEach((room) => {
     const memoTags = room.memos.map((memo) => memo.tags);
-    console.log(memoTags);
 
     allTags.push(...memoTags);
-    console.log(allTags);
 
     memoroomInfo[room._id] = {
       name: room.name,
@@ -42,6 +40,8 @@ exports.addNewMemoRoom = async (userId, roomName) => {
   await User.findByIdAndUpdate(userId, {
     $push: { rooms: newMemoRoom._id },
   }).exec();
+
+  return newMemoRoom._id;
 };
 
 exports.updateMemoRoomTitle = async (memoRoomId, roomName) => {

--- a/services/memoRoom.js
+++ b/services/memoRoom.js
@@ -4,40 +4,35 @@ const MemoRoom = require("../models/MemoRoom");
 const Chat = require("../models/Chat");
 
 exports.getAllMemoRoom = async (userId) => {
-  const memoRooms = await User.findById(userId).populate({
+  const targetUser = await User.findById(userId).populate({
     path: "rooms",
     populate: { path: "memos" },
   });
 
-  if (!Object.keys(memoRooms).length) {
-    return;
-  }
-
+  //flatMap으로 리팩토링 해보기 ..
   const allTags = [];
+  const memoroomInfo = {};
 
-  const memoroomInfo = memoRooms.rooms.map((room) => {
+  targetUser.rooms.forEach((room) => {
     const memoTags = room.memos.map((memo) => memo.tags);
-    const refinedRoom = {};
+    console.log(memoTags);
 
-    allTags.concat(memoTags);
+    allTags.push(...memoTags);
+    console.log(allTags);
 
-    refinedRoom[room._id] = {
+    memoroomInfo[room._id] = {
       name: room.name,
-      tags: Array.from(new Set(memoTags)),
+      tags: Array.from(new Set(memoTags.flat(Infinity))),
     };
-
-    return refinedRoom;
   });
 
   return {
-    tags: Array.from(new Set(allTags)),
+    tags: Array.from(new Set(allTags.flat(Infinity))),
     memoRooms: memoroomInfo,
   };
 };
 
 exports.addNewMemoRoom = async (userId, roomName) => {
-  console.log(userId, roomName);
-
   const newMemoRoom = await MemoRoom.create({
     owner: userId,
     participants: [userId],


### PR DESCRIPTION
# [1008] {refactor: 리덕스 상태값 업데이트 관련 서버 로직 변경}

## 노션 칸반 링크
- [메인페이지 메모룸 CRUD 작업](https://www.notion.so/vanillacoding/9bd990ceba744f2bbf3697ee30e36461?v=c2b08290b0ba4dc7b55e750ae4fcf979&p=d3ab9954a8184fc394a289fa1f3bfd2c)
​
## 카드에서 구현 혹은 해결하려는 내용
- 기존에 리덕스 상태값 업데이트를 위한 서버 로직이 아니어서, 클라이언트 연결 이후 서버 테스트 및 업데이트 진행함
​
